### PR TITLE
Optimize firmware usage of RAM

### DIFF
--- a/blinky/main.go
+++ b/blinky/main.go
@@ -7,6 +7,8 @@ import (
 )
 
 func main() {
+	time.Sleep(3 * time.Second)
+	println("start program")
 	const spiNOPs = 0
 	spi, cs, WL_REG_ON, irq := cyw43439.PicoWSpi(spiNOPs)
 

--- a/cy43439.go
+++ b/cy43439.go
@@ -247,9 +247,9 @@ alpset:
 		Debug("chip ID:", chipID)
 	}
 
-	if cfg.Firmware == nil {
+	if cfg.Firmware == "" {
 		return nil
-	} else if cfg.CLM == nil {
+	} else if cfg.CLM == "" {
 		return errors.New("CLM is nil but firmware not nil")
 	}
 	Debug("begin disabling cores")
@@ -285,9 +285,9 @@ alpset:
 	const RamSize = (512 * 1024)
 	wifinvramLen := align32(uint32(len(nvram43439)), 64)
 	Debug("start nvram download")
-	var nvrambuf [1024]byte
-	copy(nvrambuf[:], nvram43439)
-	err = d.downloadResource(RamSize-4-wifinvramLen, nvrambuf[:len(nvram43439)])
+	// var nvrambuf [1024]byte
+	// copy(nvrambuf[:], nvram43439)
+	err = d.downloadResource(RamSize-4-wifinvramLen, nvram43439)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ f2ready:
 
 	// Load CLM data. It's right after main firmware
 	Debug("prepare to flash CLM")
-	err = d.clmLoad(cfg.CLM)
+	err = d.clmLoad([]byte(cfg.CLM))
 	if err != nil {
 		return err
 	}

--- a/cy_ioctl.go
+++ b/cy_ioctl.go
@@ -460,12 +460,18 @@ func (d *Dev) downloadResource(addr uint32, src string) error {
 		if err != nil {
 			return err
 		}
+		var n int
 		if offset+sz > len(src) {
-			srcPtr = src[offset:]
+			n = sz
+			buf = [68]byte{}
+			if offset < len(src) {
+				copy(buf[:sz], src[offset:])
+			}
 		} else {
 			srcPtr = src[offset:]
+			n = copy(buf[:sz], srcPtr)
 		}
-		n := copy(buf[:sz], srcPtr)
+
 		err = d.WriteBytes(FuncBackplane, dstAddr&whd.BACKPLANE_ADDR_MASK, buf[:n])
 		if err != nil {
 			return err

--- a/firmware_embed.go
+++ b/firmware_embed.go
@@ -9,7 +9,7 @@ var (
 
 	// Of raw size 225240.
 	//go:embed firmware/wififw.bin
-	wifiFW []byte
+	wifiFW string
 	// Of raw size 232408 bytes
 	//go:embed firmware/wifibtfw.bin
 	wifibtFW []byte


### PR DESCRIPTION
### Before:
```
$ tinygo build -monitor -target=pico -size=short ./blinky/ 
   code    data     bss |   flash     ram
  74012  226796    3432 |  300808  230228
```

### After:
```
$ tinygo build -monitor -target=pico -size=short ./blinky/ 
   code    data     bss |   flash     ram
 299152    1556    3432 |  300708    4988
```