### PR TITLE
stub out netdev and netlink interface implmentations

### DIFF
--- a/netdev.go
+++ b/netdev.go
@@ -1,0 +1,50 @@
+// Netdev implmentation of cyw43439
+
+package cyw43439
+
+import (
+	"net"
+	"time"
+
+	"tinygo.org/x/drivers"
+)
+
+func (d *Dev) GetHostByName(name string) (net.IP, error) {
+	return net.IP{}, drivers.ErrNotSupported
+}
+
+func (d *Dev) Socket(domain int, stype int, protocol int) (int, error) {
+	return -1, drivers.ErrNotSupported
+}
+
+func (d *Dev) Bind(sockfd int, ip net.IP, port int) error {
+	return drivers.ErrNotSupported
+}
+
+func (d *Dev) Connect(sockfd int, host string, ip net.IP, port int) error {
+	return drivers.ErrNotSupported
+}
+
+func (d *Dev) Listen(sockfd int, backlog int) error {
+	return drivers.ErrNotSupported
+}
+
+func (d *Dev) Accept(sockfd int, ip net.IP, port int) (int, error) {
+	return -1, drivers.ErrNotSupported
+}
+
+func (d *Dev) Send(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
+	return 0, drivers.ErrNotSupported
+}
+
+func (d *Dev) Recv(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
+	return 0, drivers.ErrNotSupported
+}
+
+func (d *Dev) Close(sockfd int) error {
+	return drivers.ErrNotSupported
+}
+
+func (d *Dev) SetSockOpt(sockfd int, level int, opt int, value interface{}) error {
+	return drivers.ErrNotSupported
+}

--- a/netlink.go
+++ b/netlink.go
@@ -1,0 +1,27 @@
+// Netlink implmentation of cyw43439
+
+package cyw43439
+
+import (
+	"net"
+
+	"tinygo.org/x/drivers"
+)
+
+func (d *Dev) NetConnect() error {
+	return drivers.ErrNotSupported
+}
+
+func (d *Dev) NetDisconnect() {
+}
+
+func (d *Dev) NetNotify(cb func(drivers.NetlinkEvent)) {
+}
+
+func (d *Dev) GetHardwareAddr() (net.HardwareAddr, error) {
+	return net.HardwareAddr{}, drivers.ErrNotSupported
+}
+
+func (d *Dev) GetIPAddr() (net.IP, error) {
+	return net.IP{}, drivers.ErrNotSupported
+}


### PR DESCRIPTION
Stub out the netdev and netlink interfaces.  With this, I can attempt to run example/net/tcpclient.  It fails in NetConnect() with "not implemented", as expected.

This PR depends on the netdev PRs for tinygo and tinygo-drivers.