### PR TITLE
s/Dev/Device

### DIFF
--- a/blinky/main.go
+++ b/blinky/main.go
@@ -10,7 +10,7 @@ func main() {
 	const spiNOPs = 0
 	spi, cs, WL_REG_ON, irq := cyw43439.PicoWSpi(spiNOPs)
 
-	dev := cyw43439.NewDev(spi, cs, WL_REG_ON, irq, irq)
+	dev := cyw43439.NewDevice(spi, cs, WL_REG_ON, irq, irq)
 	err := dev.Init(cyw43439.DefaultConfig(false))
 	if err != nil {
 		panic(err.Error())

--- a/cy_io.go
+++ b/cy_io.go
@@ -18,24 +18,24 @@ var endian binary.ByteOrder = binary.LittleEndian
 
 var ErrDataNotAvailable = errors.New("requested data not available")
 
-func (d *Dev) Write32(fn Function, addr, val uint32) error {
+func (d *Device) Write32(fn Function, addr, val uint32) error {
 	err := d.wr(fn, addr, 4, uint32(val))
 	return err
 }
 
 // reference: cyw43_write_reg_u16
-func (d *Dev) Write16(fn Function, addr uint32, val uint16) error {
+func (d *Device) Write16(fn Function, addr uint32, val uint16) error {
 	err := d.wr(fn, addr, 2, uint32(val))
 	return err
 }
 
 // reference: cyw43_write_reg_u8
-func (d *Dev) Write8(fn Function, addr uint32, val uint8) error {
+func (d *Device) Write8(fn Function, addr uint32, val uint8) error {
 	err := d.wr(fn, addr, 1, uint32(val))
 	return err
 }
 
-func (d *Dev) wr(fn Function, addr, size, val uint32) error {
+func (d *Device) wr(fn Function, addr, size, val uint32) error {
 	var buf [4]byte
 	cmd := make_cmd(true, true, fn, addr, size)
 	if fn == FuncBackplane {
@@ -79,7 +79,7 @@ func (d *Dev) wr(fn Function, addr, size, val uint32) error {
 }
 
 // reference: cyw43_write_bytes
-func (d *Dev) WriteBytes(fn Function, addr uint32, src []byte) error {
+func (d *Device) WriteBytes(fn Function, addr uint32, src []byte) error {
 	// Debug("WriteBytes addr=", addr, "len=", len(src), "fn=", fn.String())
 	length := uint32(len(src))
 	alignedLength := (length + 3) &^ 3
@@ -117,7 +117,7 @@ func (d *Dev) WriteBytes(fn Function, addr uint32, src []byte) error {
 }
 
 // spiWrite performs the gSPI Write action. Does not control CS pin.
-func (d *Dev) spiWrite(cmd uint32, w []byte) error {
+func (d *Device) spiWrite(cmd uint32, w []byte) error {
 	var buf [4]byte
 	if sharedDATA {
 		d.sharedSD.Configure(machine.PinConfig{Mode: machine.PinOutput})
@@ -143,25 +143,25 @@ func (d *Dev) spiWrite(cmd uint32, w []byte) error {
 }
 
 // reference: cyw43_read_reg_u32
-func (d *Dev) Read32(fn Function, addr uint32) (uint32, error) {
+func (d *Device) Read32(fn Function, addr uint32) (uint32, error) {
 	v, err := d.rr(fn, addr, 4)
 	return v, err
 }
 
 // reference: cyw43_read_reg_u16
-func (d *Dev) Read16(fn Function, addr uint32) (uint16, error) {
+func (d *Device) Read16(fn Function, addr uint32) (uint16, error) {
 	v, err := d.rr(fn, addr, 2)
 	return uint16(v), err
 }
 
 // reference: cyw43_read_reg_u8
-func (d *Dev) Read8(fn Function, addr uint32) (uint8, error) {
+func (d *Device) Read8(fn Function, addr uint32) (uint8, error) {
 	v, err := d.rr(fn, addr, 1)
 	return uint8(v), err
 }
 
 // rr reads a register and returns the result and an error if there was one.
-func (d *Dev) rr(fn Function, addr, size uint32) (uint32, error) {
+func (d *Device) rr(fn Function, addr, size uint32) (uint32, error) {
 	var padding uint32
 	if fn == FuncBackplane {
 		padding = whd.BUS_SPI_BACKPLANE_READ_PADD_SIZE
@@ -188,7 +188,7 @@ func (d *Dev) rr(fn Function, addr, size uint32) (uint32, error) {
 }
 
 // reference: cyw43_read_bytes
-func (d *Dev) ReadBytes(fn Function, addr uint32, src []byte) error {
+func (d *Device) ReadBytes(fn Function, addr uint32, src []byte) error {
 	Debug("read bytes addr=", addr, "len=", len(src), "fn=", fn.String())
 	const maxReadPacket = 2040
 	length := uint32(len(src))
@@ -216,7 +216,7 @@ func (d *Dev) ReadBytes(fn Function, addr uint32, src []byte) error {
 }
 
 // spiRead performs the gSPI Read action.
-func (d *Dev) spiRead(cmd uint32, r []byte, padding uint8) error {
+func (d *Device) spiRead(cmd uint32, r []byte, padding uint8) error {
 	var buf [4]byte
 	if sharedDATA {
 		d.sharedSD.Configure(machine.PinConfig{Mode: machine.PinOutput})
@@ -243,19 +243,19 @@ func (d *Dev) spiRead(cmd uint32, r []byte, padding uint8) error {
 }
 
 //go:inline
-func (d *Dev) csHigh() {
+func (d *Device) csHigh() {
 	d.cs.High()
 	machine.GPIO1.High()
 }
 
 //go:inline
-func (d *Dev) csLow() {
+func (d *Device) csLow() {
 	d.cs.Low()
 	machine.GPIO1.Low()
 }
 
 //go:inline
-func (d *Dev) responseDelay(padding uint8) {
+func (d *Device) responseDelay(padding uint8) {
 	// Wait for response.
 	for i := uint8(0); i < padding; i++ {
 		d.spi.Transfer(0)
@@ -285,7 +285,7 @@ func swap32(b uint32) uint32 {
 }
 
 // Write32S writes register and swaps big-endian 16bit word length. Used only at initialization.
-func (d *Dev) Write32S(fn Function, addr, val uint32) error {
+func (d *Device) Write32S(fn Function, addr, val uint32) error {
 	cmd := make_cmd(true, true, fn, addr, 4)
 	var buf [4]byte
 	d.csLow()
@@ -318,7 +318,7 @@ func (d *Dev) Write32S(fn Function, addr, val uint32) error {
 }
 
 // Read32S reads register and swaps big-endian 16bit word length. Used only at initialization.
-func (d *Dev) Read32S(fn Function, addr uint32) (uint32, error) {
+func (d *Device) Read32S(fn Function, addr uint32) (uint32, error) {
 	if fn == FuncBackplane {
 		panic("backplane not implemented for rrS")
 	}

--- a/netdev.go
+++ b/netdev.go
@@ -9,42 +9,42 @@ import (
 	"tinygo.org/x/drivers"
 )
 
-func (d *Dev) GetHostByName(name string) (net.IP, error) {
+func (d *Device) GetHostByName(name string) (net.IP, error) {
 	return net.IP{}, drivers.ErrNotSupported
 }
 
-func (d *Dev) Socket(domain int, stype int, protocol int) (int, error) {
+func (d *Device) Socket(domain int, stype int, protocol int) (int, error) {
 	return -1, drivers.ErrNotSupported
 }
 
-func (d *Dev) Bind(sockfd int, ip net.IP, port int) error {
+func (d *Device) Bind(sockfd int, ip net.IP, port int) error {
 	return drivers.ErrNotSupported
 }
 
-func (d *Dev) Connect(sockfd int, host string, ip net.IP, port int) error {
+func (d *Device) Connect(sockfd int, host string, ip net.IP, port int) error {
 	return drivers.ErrNotSupported
 }
 
-func (d *Dev) Listen(sockfd int, backlog int) error {
+func (d *Device) Listen(sockfd int, backlog int) error {
 	return drivers.ErrNotSupported
 }
 
-func (d *Dev) Accept(sockfd int, ip net.IP, port int) (int, error) {
+func (d *Device) Accept(sockfd int, ip net.IP, port int) (int, error) {
 	return -1, drivers.ErrNotSupported
 }
 
-func (d *Dev) Send(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
+func (d *Device) Send(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
 	return 0, drivers.ErrNotSupported
 }
 
-func (d *Dev) Recv(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
+func (d *Device) Recv(sockfd int, buf []byte, flags int, deadline time.Time) (int, error) {
 	return 0, drivers.ErrNotSupported
 }
 
-func (d *Dev) Close(sockfd int) error {
+func (d *Device) Close(sockfd int) error {
 	return drivers.ErrNotSupported
 }
 
-func (d *Dev) SetSockOpt(sockfd int, level int, opt int, value interface{}) error {
+func (d *Device) SetSockOpt(sockfd int, level int, opt int, value interface{}) error {
 	return drivers.ErrNotSupported
 }

--- a/netlink.go
+++ b/netlink.go
@@ -8,20 +8,20 @@ import (
 	"tinygo.org/x/drivers"
 )
 
-func (d *Dev) NetConnect() error {
+func (d *Device) NetConnect() error {
 	return drivers.ErrNotSupported
 }
 
-func (d *Dev) NetDisconnect() {
+func (d *Device) NetDisconnect() {
 }
 
-func (d *Dev) NetNotify(cb func(drivers.NetlinkEvent)) {
+func (d *Device) NetNotify(cb func(drivers.NetlinkEvent)) {
 }
 
-func (d *Dev) GetHardwareAddr() (net.HardwareAddr, error) {
+func (d *Device) GetHardwareAddr() (net.HardwareAddr, error) {
 	return net.HardwareAddr{}, drivers.ErrNotSupported
 }
 
-func (d *Dev) GetIPAddr() (net.IP, error) {
+func (d *Device) GetIPAddr() (net.IP, error) {
 	return net.IP{}, drivers.ErrNotSupported
 }

--- a/shelltest/test_shellmode.go
+++ b/shelltest/test_shellmode.go
@@ -26,7 +26,7 @@ func TestShellmode() {
 	}
 	println("replicating SPI transactions on GPIOs (SDO,SDI,SCK,CS)=", mockSDO, mockSDI, mockSCK, mockCS)
 	spi.Configure()
-	dev := cyw43439.NewDev(spi, cs, wlreg, irq, irq)
+	dev := cyw43439.NewDevice(spi, cs, wlreg, irq, irq)
 	dev.GPIOSetup()
 	var _commandBuf [128]byte
 	for {


### PR DESCRIPTION
Per conversation, s/Dev/Device to be consistent with TinyGo driver naming convention.