### PR TITLE
Get irq pin working

### DIFF
--- a/cmd/cyweth/main.go
+++ b/cmd/cyweth/main.go
@@ -29,6 +29,9 @@ func main() {
 	spi, cs, wlreg, irq := cyw43439.PicoWSpi(0)
 	dev := cyw43439.NewDevice(spi, cs, wlreg, irq, irq)
 
+	// Setup Rx callback
+	dev.RecvEthHandle(rx)
+
 	// Enable device for Wifi station mode
 	country := whd.CountryCode("XX", 0)
 	if err := dev.EnableStaMode(country); err != nil {
@@ -48,9 +51,6 @@ func main() {
 	// 1. dev.GetIP()
 	// 2. dev.SendEth() implemented for Tx
 	// 3. Interrupts (or polling) for Rx
-
-	// Setup Rx callback
-	dev.RecvEthHandle(rx)
 
 	// Forever send a pkt
 	for {

--- a/cy43439.go
+++ b/cy43439.go
@@ -157,6 +157,9 @@ func NewDevice(spi drivers.SPI, cs, wlRegOn, irq, sharedSD machine.Pin) *Device 
 // ref: void cyw43_arch_enable_sta_mode()
 func (d *Device) EnableStaMode(country uint32) error {
 
+	d.lock()
+	defer d.unlock()
+
 	if err := d.Init(DefaultConfig(false)); err != nil {
 		return err
 	}
@@ -350,9 +353,6 @@ func (d *Device) sendEthernet(buf []byte) error {
 
 // reference: int cyw43_ll_bus_init(cyw43_ll_t *self_in, const uint8_t *mac)
 func (d *Device) Init(cfg Config) (err error) {
-
-	d.lock()
-	defer d.unlock()
 
 	d.fwVersion, err = getFWVersion(cfg.Firmware)
 	if err != nil {
@@ -753,9 +753,6 @@ func pmValue(pmMode, pmSleepRetMs, li_beacon_period, li_dtim_period, li_assoc ui
 // reference: cyw43_ll_wifi_on
 func (d *Device) wifiOn(country uint32) error {
 
-	d.lock()
-	defer d.unlock()
-
 	buf := d.offbuf()
 	copy(buf, "country\x00")
 	binary.LittleEndian.PutUint32(buf[8:12], country&0xff_ff)
@@ -879,9 +876,6 @@ func (d *Device) ensureUp() error {
 
 // reference: cyw43_wifi_pm
 func (d *Device) wifiPM(pm_in uint32) (err error) {
-
-	d.lock()
-	defer d.unlock()
 
 	err = d.ensureUp()
 	if err != nil {

--- a/cy43439.go
+++ b/cy43439.go
@@ -149,6 +149,7 @@ func NewDevice(spi drivers.SPI, cs, wlRegOn, irq, sharedSD machine.Pin) *Device 
 		spi:          spi,
 		cs:           cs,
 		wlRegOn:      wlRegOn,
+		irq:          irq,
 		sharedSD:     SD,
 		killWatchdog: make(chan bool),
 	}
@@ -297,11 +298,7 @@ func (d *Device) processPackets() {
 
 // ref: bool cyw43_ll_has_work(cyw43_ll_t *self_in)
 func (d *Device) hasWork() bool {
-	// TODO reading d.irq.Get() always returns ifalse, so something is
-	// wrong.  Return true for now to keep polling active and allow async
-	// event and Rx data proecssing.
-	return true
-	//return d.irq.Get()
+	return d.irq.Get()
 }
 
 // ref: void cyw43_poll_func(void)
@@ -646,6 +643,8 @@ f2ready:
 		return err
 	}
 
+	// Enable irq and start polling it
+	d.irq.Configure(machine.PinConfig{Mode: machine.PinInput})
 	d.pollStart()
 
 	return nil
@@ -692,7 +691,6 @@ func (d *Device) Reset() {
 	time.Sleep(20 * time.Millisecond)
 	d.wlRegOn.High()
 	time.Sleep(250 * time.Millisecond)
-	// d.irq.Configure(machine.PinConfig{Mode: machine.PinInput})
 }
 
 //go:inline

--- a/definitions.go
+++ b/definitions.go
@@ -269,11 +269,9 @@ func min[T _integer](a, b T) T {
 }
 
 func (d *Device) lock() {
-	Debug("LOCKING")
 	d.hw.Lock()
 }
 
 func (d *Device) unlock() {
 	d.hw.Unlock()
-	Debug("UNLOCKED")
 }


### PR DESCRIPTION
d.irg.Get() now returns true when there is work to do; polling polls it and dispatches work when true.

Getting work-to-do when new Rx pkts arrive.

Not getting async events for link status changes?