### PR TITLE
fix data race 

### DIFF
--- a/cmd/cyrw/main.go
+++ b/cmd/cyrw/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/hex"
+	"errors"
 	"time"
 
 	"github.com/soypat/cyw43439/cyrw"
 	"github.com/soypat/cyw43439/internal/slog"
+	"github.com/soypat/cyw43439/internal/tcpctl/eth"
 )
 
 func main() {
@@ -46,4 +49,44 @@ func main() {
 		time.Sleep(time.Second / 2)
 		cycle = !cycle
 	}
+}
+
+var (
+	errNotTCP     = errors.New("packet not TCP")
+	errNotIPv4    = errors.New("packet not IPv4")
+	errPacketSmol = errors.New("packet too small")
+)
+
+func rx(pkt []byte) error {
+	if len(pkt) < 14 {
+		return errPacketSmol
+	}
+	ethHdr := eth.DecodeEthernetHeader(pkt)
+	if ethHdr.AssertType() != eth.EtherTypeIPv4 {
+		return errNotIPv4
+	}
+	ipHdr := eth.DecodeIPv4Header(pkt[eth.SizeEthernetHeaderNoVLAN:])
+	println("ETH:", ethHdr.String())
+	println("IPv4:", ipHdr.String())
+	println("Rx:", len(pkt))
+	println(hex.Dump(pkt))
+	if ipHdr.Protocol == 17 {
+		// We got an UDP packet and we validate it.
+		udpHdr := eth.DecodeUDPHeader(pkt[eth.SizeEthernetHeaderNoVLAN+eth.SizeIPv4Header:])
+		gotChecksum := udpHdr.CalculateChecksumIPv4(&ipHdr, pkt[eth.SizeEthernetHeaderNoVLAN+eth.SizeIPv4Header+eth.SizeUDPHeader:])
+		println("UDP:", udpHdr.String())
+		if gotChecksum == 0 || gotChecksum == udpHdr.Checksum {
+			println("checksum match!")
+		} else {
+			println("checksum mismatch! Received ", udpHdr.Checksum, " but calculated ", gotChecksum)
+		}
+		return nil
+	}
+	if ipHdr.Protocol != 6 {
+		return errNotTCP
+	}
+	tcpHdr := eth.DecodeTCPHeader(pkt[eth.SizeEthernetHeaderNoVLAN+eth.SizeIPv4Header:])
+	println("TCP:", tcpHdr.String())
+
+	return nil
 }

--- a/cmd/cyrw/main.go
+++ b/cmd/cyrw/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	for {
 		// Set ssid/pass in secrets.go
-		err = dev.JoinWpa2(ssid, pass)
+		err = dev.JoinWPA2(ssid, pass)
 		if err == nil {
 			break
 		}

--- a/cyrw/debug.go
+++ b/cyrw/debug.go
@@ -174,3 +174,7 @@ func printLowLevelTx(cmd uint32, data []uint32) {
 	}
 	println()
 }
+
+func hex32(u uint32) string {
+	return hex.EncodeToString([]byte{byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u)})
+}

--- a/cyrw/device.go
+++ b/cyrw/device.go
@@ -23,7 +23,7 @@ func DefaultConfig() Config {
 
 // type OutputPin func(bool)
 type Device struct {
-	sync.Mutex
+	mu              sync.Mutex
 	pwr             OutputPin
 	lastStatusGet   time.Time
 	spi             spibus
@@ -67,6 +67,8 @@ func hex32(u uint32) string {
 }
 
 func (d *Device) Init(cfg Config) (err error) {
+	d.lock()
+	defer d.unlock()
 	// Reference: https://github.com/embassy-rs/embassy/blob/6babd5752e439b234151104d8d20bae32e41d714/cyw43/src/runner.rs#L76
 	err = d.initBus()
 	if err != nil {
@@ -214,3 +216,6 @@ func (d *Device) getInterrupts() Interrupts {
 	}
 	return Interrupts(irq)
 }
+
+func (d *Device) lock()   { d.mu.Lock() }
+func (d *Device) unlock() { d.mu.Unlock() }

--- a/cyrw/device.go
+++ b/cyrw/device.go
@@ -132,7 +132,6 @@ func (d *Device) Init(cfg Config) (err error) {
 		}
 		retries--
 	}
-
 	// "Set up the interrupt mask and enable interrupts"
 	d.write16(FuncBus, whd.SPI_INTERRUPT_ENABLE_REGISTER, whd.F2_PACKET_AVAILABLE)
 
@@ -166,7 +165,7 @@ func (d *Device) Init(cfg Config) (err error) {
 	}
 
 	// Starting polling to simulate hw interrupts
-	go d.poll()
+	go d.irqPoll()
 
 	err = d.initControl(cfg.CLM)
 	if err != nil {
@@ -205,6 +204,7 @@ func (d *Device) SendEth(pkt []byte) error {
 
 // status gets gSPI last bus status or reads it from the device if it's stale, for some definition of stale.
 func (d *Device) status() Status {
+	// TODO(soypat): Are we sure we don't want to re-acquire status if it's been very long?
 	sinceStat := time.Since(d.lastStatusGet)
 	if sinceStat < 12*time.Microsecond {
 		runtime.Gosched() // Probably in hot loop.

--- a/cyrw/ioctl.go
+++ b/cyrw/ioctl.go
@@ -296,7 +296,7 @@ func (d *Device) poll() {
 // the packet length.
 func (d *Device) f2PacketAvail() (bool, uint16) {
 	// First, check cached status from previous cmd_read|cmd_write
-	status := d.spi.Status()
+	status := d.status()
 	if status.F2PacketAvailable() {
 		return true, status.F2PacketLength()
 	}
@@ -304,7 +304,7 @@ func (d *Device) f2PacketAvail() (bool, uint16) {
 	// status
 	irq := d.getInterrupts()
 	if irq.IsF2Available() {
-		status = d.spi.Status()
+		status = d.status()
 		if status.F2PacketAvailable() {
 			return true, status.F2PacketLength()
 		}

--- a/cyrw/ioctl.go
+++ b/cyrw/ioctl.go
@@ -447,10 +447,11 @@ func (d *Device) rxEvent(packet []byte) error {
 }
 
 func (d *Device) rxData(packet []byte) (err error) {
-	bdcHdr := whd.DecodeBDCHeader(packet)
-	packetStart := whd.BDC_HEADER_LEN + 4*int(bdcHdr.DataOffset)
-	payload := packet[packetStart:]
-	d.debug("rxData", slog.Int("payload len", len(payload)), slog.Any("bdc", &bdcHdr))
-	println(hex.Dump(payload))
+	if d.rcvEth != nil {
+		bdcHdr := whd.DecodeBDCHeader(packet)
+		packetStart := whd.BDC_HEADER_LEN + 4*int(bdcHdr.DataOffset)
+		payload := packet[packetStart:]
+		return d.rcvEth(payload)
+	}
 	return nil
 }

--- a/whd/protocol.go
+++ b/whd/protocol.go
@@ -309,6 +309,11 @@ type EventMessage struct {
 	BSSCfgIdx uint8          // 47:48
 }
 
+// Common async event errors.
+var (
+	ErrInvalidEtherType = errors.New("whd: invalid EtherType")
+)
+
 // DecodeEventPacket decodes an async event packet. Requires 72 byte buffer.
 func DecodeEventPacket(order binary.ByteOrder, buf []byte) (ev EventPacket, err error) {
 	// https://github.com/embassy-rs/embassy/blob/26870082427b64d3ca42691c55a2cded5eadc548/cyw43/src/structs.rs#L234C18-L234C18
@@ -318,7 +323,7 @@ func DecodeEventPacket(order binary.ByteOrder, buf []byte) (ev EventPacket, err 
 	}
 	ev.EthHeader = eth.DecodeEthernetHeader(buf[:14])
 	if ev.EthHeader.AssertType() != 0x886c {
-		return ev, errors.New("invalid ethertype")
+		return ev, ErrInvalidEtherType
 	}
 	ev.EventHeader = DecodeEventHeader(order, buf[14:24])
 	const (


### PR DESCRIPTION
Data race in Device buffers since we had an async routine `poll()` that would eventually call wlan_read and possibly other routines that share spibus buffers.

We can optimize this in future.