### PR TITLE
change device to support Netlinker interface

### DIFF
--- a/bus_pico_pio.go
+++ b/bus_pico_pio.go
@@ -4,6 +4,7 @@ package cyw43439
 
 import (
 	"encoding/binary"
+	"log/slog"
 	"machine"
 
 	pio "github.com/tinygo-org/pio/rp2-pio"
@@ -18,7 +19,7 @@ type spibus struct {
 	spi piolib.SPI3w
 }
 
-func NewPicoWDevice() *Device {
+func NewPicoWDevice(logger *slog.Logger) *Device {
 	// Raspberry Pi Pico W pin definitions for the CY43439.
 	const (
 		// IRQ       = machine.GPIO24 // AKA WL_HOST_WAKE
@@ -47,7 +48,7 @@ func NewPicoWDevice() *Device {
 	return New(WL_REG_ON.Set, CS.Set, spibus{
 		cs:  CS.Set,
 		spi: *spi,
-	})
+	}, logger)
 }
 
 func (d *spibus) cmd_read(cmd uint32, buf []uint32) (status uint32, err error) {

--- a/device.go
+++ b/device.go
@@ -2,7 +2,6 @@ package cyw43439
 
 import (
 	"errors"
-	"net"
 	"runtime"
 	"sync"
 	"time"
@@ -198,90 +197,6 @@ func (d *Device) GPIOSet(wlGPIO uint8, value bool) (err error) {
 	d.lock()
 	defer d.unlock()
 	return d.set_iovar2("gpioout", whd.IF_STA, val0, val1)
-}
-
-func (d *Device) GetHardwareAddr() (net.HardwareAddr, error) {
-	return net.HardwareAddr(d.mac[:6]), nil
-}
-
-func (d *Device) NetNotify(cb func(netlink.Event)) {
-	d.notifyCb = cb
-}
-
-func (d *Device) NetConnect(params *netlink.ConnectParams) error {
-
-	if d.netConnected {
-		return netlink.ErrConnected
-	}
-
-	cfg := DefaultWifiConfig()
-	if err := d.Init(cfg); err != nil {
-		return err
-	}
-
-	for i := 0; params.Retries == 0 || i < params.Retries; i++ {
-		err := d.JoinWPA2(params.Ssid, params.Passphrase)
-		if err == nil {
-			d.netConnected = true
-			break
-		}
-		println("wifi join failed:", err.Error())
-	}
-
-	if !d.netConnected {
-		return netlink.ErrConnectFailed
-	}
-
-	mac, _ := d.GetHardwareAddr()
-	println("\n\n\nMAC:", mac.String())
-
-	if d.notifyCb != nil {
-		d.notifyCb(netlink.EventNetUp)
-	}
-
-	/*
-	if params.WatchdogTimeout != 0 {
-		go d.watchdog()
-	}
-	*/
-
-	return nil
-}
-
-func (d *Device) NetDisconnect() {
-
-	if !d.netConnected {
-		return
-	}
-
-	/*
-	if d.params.WatchdogTimeout != 0 {
-		d.killWatchdog <- true
-	}
-	*/
-
-	// TODO disconnect
-
-	d.netConnected = false
-
-	if d.notifyCb != nil {
-		d.notifyCb(netlink.EventNetDown)
-	}
-}
-
-// RecvEthHandle sets handler for receiving Ethernet pkt
-// If set to nil then incoming packets are ignored.
-func (d *Device) RecvEthHandle(handler func(pkt []byte) error) {
-	d.lock()
-	defer d.unlock()
-	d.rcvEth = handler
-}
-
-// SendEth sends an Ethernet packet over the current interface.
-func (d *Device) SendEth(pkt []byte) error {
-	d.lock()
-	defer d.unlock()
-	return d.tx(pkt)
 }
 
 // status gets gSPI last bus status or reads it from the device if it's stale, for some definition of stale.

--- a/ioctl.go
+++ b/ioctl.go
@@ -290,7 +290,7 @@ func (d *Device) TryPoll() (gotPacket bool, err error) {
 	if err == errNoF2Avail {
 		return false, nil
 	}
-	return err == nil && cmd == whd.CONTROL_HEADER, err
+	return err == nil && cmd == whd.DATA_HEADER, err
 }
 
 // poll services any F2 packets.

--- a/netlink.go
+++ b/netlink.go
@@ -1,0 +1,96 @@
+package cyw43439
+
+import (
+	"net"
+
+	"tinygo.org/x/drivers/netlink"
+)
+
+func (d *Device) GetHardwareAddr() (net.HardwareAddr, error) {
+	return net.HardwareAddr(d.mac[:6]), nil
+}
+
+func (d *Device) NetNotify(cb func(netlink.Event)) {
+	d.notifyCb = cb
+}
+
+func (d *Device) NetConnect(params *netlink.ConnectParams) error {
+
+	if d.netConnected {
+		return netlink.ErrConnected
+	}
+
+	cfg := DefaultWifiConfig()
+	if err := d.Init(cfg); err != nil {
+		return err
+	}
+
+	for i := 0; params.Retries == 0 || i < params.Retries; i++ {
+		err := d.JoinWPA2(params.Ssid, params.Passphrase)
+		if err == nil {
+			d.netConnected = true
+			break
+		}
+		println("wifi join failed:", err.Error())
+	}
+
+	if !d.netConnected {
+		return netlink.ErrConnectFailed
+	}
+
+	mac, _ := d.GetHardwareAddr()
+	println("\n\n\nMAC:", mac.String())
+
+	if d.notifyCb != nil {
+		d.notifyCb(netlink.EventNetUp)
+	}
+
+	/*
+	if params.WatchdogTimeout != 0 {
+		go d.watchdog()
+	}
+	*/
+
+	return nil
+}
+
+func (d *Device) NetDisconnect() {
+
+	if !d.netConnected {
+		return
+	}
+
+	/*
+	if d.params.WatchdogTimeout != 0 {
+		d.killWatchdog <- true
+	}
+	*/
+
+	// TODO disconnect
+
+	d.netConnected = false
+
+	if d.notifyCb != nil {
+		d.notifyCb(netlink.EventNetDown)
+	}
+}
+
+// RecvEthHandle sets handler for receiving Ethernet pkt
+// If set to nil then incoming packets are ignored.
+func (d *Device) RecvEthHandle(handler func(pkt []byte) error) {
+	d.lock()
+	defer d.unlock()
+	d.rcvEth = handler
+}
+
+// SendEth sends an Ethernet packet over the current interface.
+func (d *Device) SendEth(pkt []byte) error {
+	d.lock()
+	defer d.unlock()
+	return d.tx(pkt)
+}
+
+// PollOne tries to receive one Ethernet packet and returns true if one was
+func (d *Device) PollOne() (gotPacket bool, err error) {
+	return d.TryPoll()
+}


### PR DESCRIPTION
In an effort to get drivers/examples/net example apps to run against cyw43439 + seqs/stack, implement Netlinker interface on cyw43439.

Implement enough to get link UP and get a DHCP IP addr.  Socket() on function are not implemented, just stubbed out.