### PR TITLE
Update http example to run on default port 80

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -72,7 +72,7 @@ func main() {
 		panic("setup DHCP:" + err.Error())
 	}
 	// Start TCP server.
-	const listenPort = 1234
+	const listenPort = 80
 	listenAddr := netip.AddrPortFrom(stack.Addr(), listenPort)
 	listener, err := stacks.NewTCPListener(stack, stacks.TCPListenerConfig{
 		MaxConnections: maxconns,


### PR DESCRIPTION
This is a minor change, but means the http example will "just work" if you just enter the IP address. My serial monitor was not working (timing?), and I could see the pi was up, read the code and then got it working - but this would have saved me a couple of minutes of head-scratching - plus, it's the default for http.

Awesome code btw :clap:
