### PR TITLE
netif.InterfaceEthPoller implementation: add netif.go and deprecated.go

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -1,12 +1,23 @@
 package cyw43439
 
+import "sync"
+
 // Functions deprecated due to naming changes to adapt to netif
 // package github.com/soypat/netif.
+
+var deprecated sync.Once
+
+func printDeprecationOnce() {
+	deprecated.Do(func() {
+		println("github.com/soypat/cyw43439: use of deprecated MACAs6 or TryPoll *Device method. Will be removed in future version. This message is only printed once")
+	})
+}
 
 // MACAs6
 //
 // Deprecated: Use HardwareAddr6() instead.
 func (d *Device) MACAs6() [6]byte {
+	printDeprecationOnce()
 	mac, _ := d.HardwareAddr6()
 	return mac
 }
@@ -15,5 +26,6 @@ func (d *Device) MACAs6() [6]byte {
 //
 // Deprecated: Use PollOne instead.
 func (d *Device) TryPoll() (gotPacket bool, err error) {
+	printDeprecationOnce()
 	return d.PollOne()
 }

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,19 @@
+package cyw43439
+
+// Functions deprecated due to naming changes to adapt to netif
+// package github.com/soypat/netif.
+
+// MACAs6
+//
+// Deprecated: Use HardwareAddr6() instead.
+func (d *Device) MACAs6() [6]byte {
+	mac, _ := d.HardwareAddr6()
+	return mac
+}
+
+// TryPoll
+//
+// Deprecated: Use PollOne instead.
+func (d *Device) TryPoll() (gotPacket bool, err error) {
+	return d.PollOne()
+}

--- a/device.go
+++ b/device.go
@@ -198,21 +198,6 @@ func (d *Device) GPIOSet(wlGPIO uint8, value bool) (err error) {
 	return d.set_iovar2("gpioout", whd.IF_STA, val0, val1)
 }
 
-// RecvEthHandle sets handler for receiving Ethernet pkt
-// If set to nil then incoming packets are ignored.
-func (d *Device) RecvEthHandle(handler func(pkt []byte) error) {
-	d.lock()
-	defer d.unlock()
-	d.rcvEth = handler
-}
-
-// SendEth sends an Ethernet packet over the current interface.
-func (d *Device) SendEth(pkt []byte) error {
-	d.lock()
-	defer d.unlock()
-	return d.tx(pkt)
-}
-
 // status gets gSPI last bus status or reads it from the device if it's stale, for some definition of stale.
 func (d *Device) status() Status {
 	// TODO(soypat): Are we sure we don't want to re-acquire status if it's been very long?

--- a/examples/dhcp/main.go
+++ b/examples/dhcp/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/soypat/cyw43439/examples/common"
+	"github.com/soypat/seqs/eth/dhcp"
 )
 
 // Setup Wifi Password and SSID in common/secrets.go
@@ -23,7 +24,7 @@ func main() {
 		RequestedIP: "10.94.2.0",
 		UDPPorts:    1,
 	})
-	if !client.IsDone() {
+	if client.State() != dhcp.StateBound {
 		println("DHCP did not complete succesfully")
 	}
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/soypat/natiu-mqtt v0.5.1
 	github.com/soypat/saleae v0.0.0-20230402180913-3584b7515dae
-	github.com/soypat/seqs v0.0.0-20240315041335-3dd1de606d2f
+	github.com/soypat/seqs v0.0.0-20240430175138-8b6dcdb5a416
 	github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899
 	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/soypat/natiu-mqtt v0.5.1 h1:rwaDmlvjzD2+3MCOjMZc4QEkDkNwDzbct2TJbpz+T
 github.com/soypat/natiu-mqtt v0.5.1/go.mod h1:xEta+cwop9izVCW7xOx2W+ct9PRMqr0gNVkvBPnQTc4=
 github.com/soypat/saleae v0.0.0-20230402180913-3584b7515dae h1:cOw342W+mYwRaahnxdhRVITGkGTTWqwy7AblKv0iQxM=
 github.com/soypat/saleae v0.0.0-20230402180913-3584b7515dae/go.mod h1:9SV+w6E9YK/BePxdxYGXthkrRztHJCQlojWOjAxW3M4=
-github.com/soypat/seqs v0.0.0-20240315041335-3dd1de606d2f h1:lONveayNmHEWUmDxfGnqd3Ww8/1QhQpwBoEXNyWZuBI=
-github.com/soypat/seqs v0.0.0-20240315041335-3dd1de606d2f/go.mod h1:oCVCNGCHMKoBj97Zp9znLbQ1nHxpkmOY9X+UAGzOxc8=
+github.com/soypat/seqs v0.0.0-20240430175138-8b6dcdb5a416 h1:fN5nKTixCj/Nhmrh+DZd86AJXFqXsvWh52vfT9452HQ=
+github.com/soypat/seqs v0.0.0-20240430175138-8b6dcdb5a416/go.mod h1:oCVCNGCHMKoBj97Zp9znLbQ1nHxpkmOY9X+UAGzOxc8=
 github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899 h1:/DyaXDEWMqoVUVEJVJIlNk1bXTbFs8s3Q4GdPInSKTQ=
 github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899/go.mod h1:LU7Dw00NJ+N86QkeTGjMLNkYcEYMor6wTDpTCu0EaH8=
 golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691 h1:/yRP+0AN7mf5DkD3BAI6TOFnd51gEoDEb8o35jIFtgw=

--- a/ioctl.go
+++ b/ioctl.go
@@ -303,18 +303,6 @@ func (d *Device) handle_irq(buf []uint32) (err error) {
 	return err
 }
 
-// TryPoll attempts to read a packet from the device. Returns true if a packet
-// was read, false if no packet was available.
-func (d *Device) TryPoll() (gotPacket bool, err error) {
-	d.lock()
-	defer d.unlock()
-	_, cmd, err := d.tryPoll(d._rxBuf[:])
-	if err == errNoF2Avail {
-		return false, nil
-	}
-	return err == nil && cmd == whd.CONTROL_HEADER, err
-}
-
 // poll services any F2 packets.
 //
 // This is the moral equivalent of an ISR to service hw interrupts.  In this

--- a/netif.go
+++ b/netif.go
@@ -1,0 +1,73 @@
+package cyw43439
+
+import (
+	"errors"
+	"net"
+
+	"github.com/soypat/cyw43439/whd"
+)
+
+// MTU (maximum transmission unit) returns the maximum amount
+// of bytes that can be sent in a single ethernet frame in a call to SendEth.
+func (d *Device) MTU() int { return MTU }
+
+// HardwareAddr6 returns the device's 6-byte [MAC address].
+//
+// [MAC address]: https://en.wikipedia.org/wiki/MAC_address
+func (d *Device) HardwareAddr6() ([6]byte, error) {
+	d.lock()
+	defer d.unlock()
+	if d.mac == [6]byte{} {
+		return [6]byte{}, errors.New("hardware address not acquired")
+	}
+	d.MACAs6()
+	return d.mac, nil
+}
+
+// PollOne attempts to read a packet from the device. Returns true if a packet
+// was read, false if no packet was available.
+func (d *Device) PollOne() (bool, error) {
+	d.lock()
+	defer d.unlock()
+	_, cmd, err := d.tryPoll(d._rxBuf[:])
+	if err == errNoF2Avail {
+		return false, nil
+	}
+	return cmd == whd.CONTROL_HEADER && err == nil, err
+}
+
+// RecvEthHandle sets handler for receiving Ethernet pkt
+// If set to nil then incoming packets are ignored.
+func (d *Device) RecvEthHandle(handler func(pkt []byte) error) {
+	d.lock()
+	defer d.unlock()
+	d.rcvEth = handler
+}
+
+// SendEth sends an Ethernet packet over the current interface.
+func (d *Device) SendEth(pkt []byte) error {
+	d.lock()
+	defer d.unlock()
+	return d.tx(pkt)
+}
+
+// NetFlags returns the current network flags for the device.
+func (d *Device) NetFlags() (flags net.Flags) {
+	// Define net.Flags locally since not all Tinygo versions have them fully defined.
+	const (
+		FlagUp           net.Flags = 1 << iota // interface is administratively up
+		FlagBroadcast                          // interface supports broadcast access capability
+		FlagLoopback                           // interface is a loopback interface
+		FlagPointToPoint                       // interface belongs to a point-to-point link
+		FlagMulticast                          // interface supports multicast access capability
+		FlagRunning                            // interface is in running state
+	)
+	if d.state == linkStateDown {
+		return 0
+	}
+	flags |= FlagUp // TODO: does this device support broadcast/multicast?
+	if d.state == linkStateUp {
+		flags |= FlagRunning
+	}
+	return flags
+}

--- a/netif.go
+++ b/netif.go
@@ -20,7 +20,6 @@ func (d *Device) HardwareAddr6() ([6]byte, error) {
 	if d.mac == [6]byte{} {
 		return [6]byte{}, errors.New("hardware address not acquired")
 	}
-	d.MACAs6()
 	return d.mac, nil
 }
 

--- a/wifi.go
+++ b/wifi.go
@@ -125,11 +125,6 @@ func (d *Device) hwaddr() net.HardwareAddr {
 	return net.HardwareAddr(d.mac[:6])
 }
 
-func (d *Device) MACAs6() [6]byte {
-	d.trace("MACAs6:call")
-	return d.mac
-}
-
 func (d *Device) set_power_management(mode powerManagementMode) error {
 	d.debug("set_power_management", slog.String("mode", mode.String()))
 	if !mode.IsValid() {


### PR DESCRIPTION
Deprecate TryPoll and MACAs6 in favor of names PollOne and HardwareAddr6.

Also remove use of stacks.DHCPClient.IsDone since also deprecated.