### PR TITLE
simplify http-server example

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -1,76 +1,43 @@
 package main
 
 import (
-	"bufio"
-	"io"
 	"log/slog"
 	"machine"
+	"net/http"
 	"net/netip"
 	"time"
 
 	_ "embed"
 
-	"github.com/soypat/cyw43439"
 	"github.com/soypat/cyw43439/examples/common"
-	"github.com/soypat/seqs/httpx"
 	"github.com/soypat/seqs/stacks"
 )
 
 const connTimeout = 3 * time.Second
 const maxconns = 3
 const tcpbufsize = 2030 // MTU - ethhdr - iphdr - tcphdr
-const hostname = "http-pico"
+const hostname = "TCP-pico"
 
-var (
-	// We embed the html file in the binary so that we can edit
-	// index.html with pretty syntax highlighting.
-	//
-	//go:embed index.html
-	webPage      []byte
-	dev          *cyw43439.Device
-	lastLedState bool
-)
-
-// This is our HTTP hander. It handles ALL incoming requests. Path routing is left
-// as an excercise to the reader.
-func HTTPHandler(respWriter io.Writer, resp *httpx.ResponseHeader, req *httpx.RequestHeader) {
-	uri := string(req.RequestURI())
-	resp.SetConnectionClose()
-	switch uri {
-	case "/":
-		println("Got webpage request!")
-		resp.SetContentType("text/html")
-		resp.SetContentLength(len(webPage))
-		respWriter.Write(resp.Header())
-		respWriter.Write(webPage)
-
-	case "/toggle-led":
-		println("Got toggle led request!")
-		respWriter.Write(resp.Header())
-		lastLedState = !lastLedState
-		dev.GPIOSet(0, lastLedState)
-
-	default:
-		println("Path not found:", uri)
-		resp.SetStatusCode(404)
-		respWriter.Write(resp.Header())
-	}
-}
+// We embed the html file in the binary so that we can edit
+// index.html with pretty syntax highlighting.
+//
+//go:embed index.html
+var webPage []byte
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(machine.Serial, &slog.HandlerOptions{
 		Level: slog.LevelDebug - 2,
 	}))
 	time.Sleep(time.Second)
-	_, stack, devlocal, err := common.SetupWithDHCP(common.SetupConfig{
-		Hostname: "TCP-pico",
+	_, stack, dev, err := common.SetupWithDHCP(common.SetupConfig{
+		Hostname: hostname,
 		Logger:   logger,
 		TCPPorts: 1,
 	})
-	dev = devlocal
 	if err != nil {
 		panic("setup DHCP:" + err.Error())
 	}
+
 	// Start TCP server.
 	const listenPort = 80
 	listenAddr := netip.AddrPortFrom(stack.Addr(), listenPort)
@@ -86,38 +53,26 @@ func main() {
 	if err != nil {
 		panic("listener start:" + err.Error())
 	}
-	// Reuse the same buffers for each connection to avoid heap allocations.
-	var req httpx.RequestHeader
-	var resp httpx.ResponseHeader
-	buf := bufio.NewReaderSize(nil, 1024)
-	logger.Info("listening",
-		slog.String("addr", "http://"+listenAddr.String()),
-	)
+	logger.Info("listening", slog.String("addr", "http://"+listenAddr.String()))
 
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			logger.Error("listener accept:", slog.String("err", err.Error()))
-			time.Sleep(time.Second)
-			continue
+	var lastLedState bool
+	http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header := w.Header()
+		header.Set("Connection", "close")
+		switch r.URL.Path {
+		case "/":
+			logger.Info("Got webpage request!")
+			header.Set("Content-Type", "text/html")
+			w.Write(webPage)
+
+		case "/toggle-led":
+			logger.Info("Got toggle led request!")
+			lastLedState = !lastLedState
+			dev.GPIOSet(0, lastLedState)
+
+		default:
+			logger.Info("Path not found", slog.String("path", r.URL.Path))
+			w.WriteHeader(http.StatusNotFound)
 		}
-		logger.Info("new connection", slog.String("remote", conn.RemoteAddr().String()))
-		err = conn.SetDeadline(time.Now().Add(connTimeout))
-		if err != nil {
-			conn.Close()
-			logger.Error("conn set deadline:", slog.String("err", err.Error()))
-			continue
-		}
-		buf.Reset(conn)
-		err = req.Read(buf)
-		if err != nil {
-			logger.Error("hdr read:", slog.String("err", err.Error()))
-			conn.Close()
-			continue
-		}
-		resp.Reset()
-		HTTPHandler(conn, &resp, &req)
-		// time.Sleep(100 * time.Millisecond)
-		conn.Close()
-	}
+	}))
 }


### PR DESCRIPTION
I was working on an HTTP endpoint that requires a POST body, but found it difficult to understand how to hold the [httpx package](https://pkg.go.dev/github.com/soypat/seqs/httpx) in a way that allowed me to obtain the body contents as the request type does not expose the content length and does not allow a read to `io.EOF` of the net conn.

If I attempt to read the contents of `buf` to completion after the [headers have been read](https://github.com/soypat/cyw43439/blob/ae1ce0e084c560349508c5c8a78d7b69854073d1/examples/http-server/main.go#L111-L112), I get a "curl: (52) Empty reply from server" from the test client and see `level=ERROR msg=Stack.RecvEth err="dropped packet"` and `poll error: dropped packet` in the server logs.

This appears to be due to the request waiting on the response because the buffer believes the conn still has data; I see this: `level=ERROR msg="read body" err="i/o timeout"`. It seems I need to know the content length to be able to know when to stop.

To get around this I tried using the standard library's net/http package in the servers code and it works. This change is the equivalent change for the http-server example.

Note that while it works (and in the server that I am writing that prompted this does not cause any `poll error: dropped packet` error to be emitted, I do see that happening in the server example. I have been unable to see how the two programs differ in a way that would explain this. The error is coming from [`(*TCPListener).recv`](https://github.com/soypat/seqs/blob/1201bab640ef437b5c167449a554bea9f5199a42/stacks/tcplistener.go#L153-L156).