### PR TITLE
simplify wifi credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tinygo flash -target=pico -stack-size=8kb -monitor  ./examples/blinky
 
 1. Clone this repository
 
-2. Rename [`examples/common/secrets.go.template`](examples/common/secrets.go.template) to have the `.go` extension and edit the contents with `ssid` and `pass` strings set to your WIFI SSID and Password, respecively. If `pass` is not set then an open network is assumed.
+2. Create ssid.text and password.text files in the [`examples/common`](examples/common) directory. Write your SSID into ssid.text and WiFi password into password.text. Do not add final newlines to the files. If the password is empty then an open network is assumed.
 
 3. Run any of the examples in the [`examples`](./examples) directory
 

--- a/examples/common/.gitignore
+++ b/examples/common/.gitignore
@@ -1,0 +1,2 @@
+password.text
+ssid.text

--- a/examples/common/common.go
+++ b/examples/common/common.go
@@ -8,6 +8,8 @@ import (
 	"net/netip"
 	"time"
 
+	_ "embed"
+
 	"github.com/soypat/cyw43439"
 	"github.com/soypat/seqs/eth/dhcp"
 	"github.com/soypat/seqs/eth/dns"
@@ -27,6 +29,15 @@ type SetupConfig struct {
 	// Number of TCP ports to open for the stack.
 	TCPPorts uint16
 }
+
+var (
+	// Put the SSID and password text in ssid.text and password.text.
+	//
+	//go:embed ssid.text
+	ssid string
+	//go:embed password.text
+	pass string
+)
 
 func SetupWithDHCP(cfg SetupConfig) (*stacks.DHCPClient, *stacks.PortStack, *cyw43439.Device, error) {
 	cfg.UDPPorts++ // Add extra UDP port for DHCP client.
@@ -68,7 +79,7 @@ func SetupWithDHCP(cfg SetupConfig) (*stacks.DHCPClient, *stacks.PortStack, *cyw
 		if err == nil {
 			break
 		}
-		logger.Error("wifi join faled", slog.String("err", err.Error()))
+		logger.Error("wifi join failed", slog.String("err", err.Error()))
 		time.Sleep(5 * time.Second)
 	}
 	mac, _ := dev.HardwareAddr6()

--- a/examples/common/secrets.go.template
+++ b/examples/common/secrets.go.template
@@ -1,9 +1,0 @@
-// Copy this file to secrets.go and make local changes to set Wifi credentials
-
-package common
-
-const (
-	// Set your Wifi SSID and passphrase here
-	ssid = ""
-	pass = ""
-)


### PR DESCRIPTION
This simplifies the configuration of wifi creds in the example programs to avoid having to construct Go source to hold the details.