### PR TITLE
fix: really correct length being returned and used for BLE HCI reads

### DIFF
--- a/bluetooth.go
+++ b/bluetooth.go
@@ -262,8 +262,8 @@ func (d *Device) hci_read(b []byte) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	length := uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16
-	hciLength := length + 4 // Add 3 bytes for SDIO header, plus 1 for packet type
+	length := 1 + (uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16) // plus 1 for packet type
+	hciLength := length + 3                                           // plus 3 bytes for SDIO header
 	roundedLength := alignup(hciLength, 4)
 	if len(b) < int(roundedLength) {
 		println("short buffer: length=", length, "hcilen", hciLength, "rlen", roundedLength, "buflen", len(b))
@@ -277,13 +277,13 @@ func (d *Device) hci_read(b []byte) (uint32, error) {
 	// Release bus.
 	err = d.bt_toggle_intr()
 	if err != nil {
-		return hciLength, err
+		return length, err
 	}
 	err = d.bt_bus_release()
 	if err != nil {
-		return hciLength, err
+		return length, err
 	}
-	return hciLength, nil
+	return length, nil
 }
 
 // hci_wait_read_buffered blocks until there are at least n bytes ready to read.


### PR DESCRIPTION
Did some more testing, and found that the previous fix did not actually work, for example with the "beacon" example.

Went back and created this PR, which has been tested in the following examples:

- scanner
- heartrate
- beacon

So I am pretty confident it is in fact correct.