### PR TITLE
fix: PollOne returns true for all received packets; drain up to 8 per…

### DIFF
--- a/examples/common/common.go
+++ b/examples/common/common.go
@@ -269,7 +269,8 @@ func nicLoop(dev *cyw43439.Device, Stack *stacks.PortStack) {
 	for {
 		stallRx := true
 		// Poll for incoming packets.
-		for i := 0; i < 1; i++ {
+		const maxRxPerCycle = 8
+		for i := 0; i < maxRxPerCycle; i++ {
 			gotPacket, err := dev.PollOne()
 			if err != nil {
 				println("poll error:", err.Error())
@@ -325,4 +326,43 @@ func nicLoop(dev *cyw43439.Device, Stack *stacks.PortStack) {
 			}
 		}
 	}
+}
+
+// Reconnect rejoins the WiFi network and re-acquires an IP address via DHCP.
+// Call this when dev.NetFlags() reports the link is down.
+// Returns a new DHCPClient that replaces the old one.
+func Reconnect(dev *cyw43439.Device, stack *stacks.PortStack, hostname string, logger *slog.Logger) (*stacks.DHCPClient, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.Level(127)}))
+	}
+	logger.Info("reconnect: joining WiFi...")
+	for {
+		err := dev.JoinWPA2(ssid, pass)
+		if err == nil {
+			break
+		}
+		logger.Error("reconnect: join failed", slog.String("err", err.Error()))
+		time.Sleep(5 * time.Second)
+	}
+	logger.Info("reconnect: WiFi joined, requesting DHCP...")
+	// Close the old DHCP port so NewDHCPClient can re-register on the same port.
+	stack.CloseUDP(dhcp.DefaultClientPort)
+	newClient := stacks.NewDHCPClient(stack, dhcp.DefaultClientPort)
+	err := newClient.BeginRequest(stacks.DHCPRequestConfig{
+		Xid:      uint32(time.Now().Nanosecond()),
+		Hostname: hostname,
+	})
+	if err != nil {
+		return nil, errors.New("reconnect: dhcp begin: " + err.Error())
+	}
+	for i := 0; newClient.State() != dhcp.StateBound; i++ {
+		time.Sleep(500 * time.Millisecond)
+		if i > 20 {
+			return nil, errors.New("reconnect: DHCP timed out")
+		}
+	}
+	ip := newClient.Offer()
+	stack.SetAddr(ip)
+	logger.Info("reconnect: complete", slog.String("ip", ip.String()))
+	return newClient, nil
 }

--- a/netif.go
+++ b/netif.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"log/slog"
 	"net"
-
-	"github.com/soypat/cyw43439/whd"
 )
 
 // MTU (maximum transmission unit) returns the maximum amount
@@ -35,11 +33,11 @@ func (d *Device) PollOne() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	_, cmd, err := d.tryPoll(d._rxBuf[:])
+	_, _, err = d.tryPoll(d._rxBuf[:])
 	if err == errNoF2Avail {
 		return false, nil
 	}
-	return cmd == whd.CONTROL_HEADER && err == nil, err
+	return err == nil, err
 }
 
 // RecvEthHandle sets handler for receiving Ethernet pkt


### PR DESCRIPTION
… cycle

Bug 1 (netif.go): PollOne() was returning true only for CONTROL_HEADER packets. DATA_HEADER (all TCP/IP traffic) and ASYNCEVENT_HEADER returned false, causing nicLoop to sleep 51ms after every Ethernet frame. This injected 200ms+ latency per TCP connection and delayed FIN teardown, exhausting the 3-slot connection pool.

Fix: return true for any packet successfully consumed from the F2 FIFO. Drop the now-unused whd import and cmd variable.

Bug 3 (common.go): nicLoop polled at most one packet per outer iteration. Under TCP burst traffic (SYN/ACK/FIN sequences), remaining packets queued in the CYW43439 hardware FIFO, causing retransmits and buffer saturation.

Fix: drain up to 8 packets per cycle; break early when FIFO is empty.

Feature (common.go): add Reconnect() to rejoin WiFi and re-acquire a DHCP address without restarting nicLoop or the TCP listener.