### PR TITLE
fix: hci_available_ringbuf to return unread bytes

### DIFF
--- a/bluetooth.go
+++ b/bluetooth.go
@@ -225,21 +225,22 @@ func (d *Device) bt_upload_firmware(firmware string) error {
 	return nil
 }
 
-// hci_available_ringbuf what does this function return? Total bytes to end of ringbuffer??
-func (d *Device) hci_available_ringbuf() (uint32, error) {
+// hci_unread_bytes returns the number of bytes the chip has written to the
+// ring buffer that have not yet been consumed.
+func (d *Device) hci_unread_bytes() (uint32, error) {
 	newPtr, err := d.bp_read32(d.btaddr + whd.BTSDIO_OFFSET_BT2HOST_IN)
 	if err != nil {
 		return 0, err
 	}
-	available := (d.b2hReadPtr - newPtr) % whd.BTSDIO_FWBUF_SIZE
-	d.trace("hci_available_ringbuf", slog.Uint64("available", uint64(available)))
-	return available, nil
+	unread := (newPtr - d.b2hReadPtr) % whd.BTSDIO_FWBUF_SIZE
+	d.trace("hci_unread_bytes", slog.Uint64("unread", uint64(unread)))
+	return unread, nil
 }
 
 func (d *Device) hci_buffered() (uint32, error) {
 	// Check if buffer contains data.
-	available, err := d.hci_available_ringbuf()
-	if available < 4 {
+	unread, err := d.hci_unread_bytes()
+	if unread < 4 {
 		return 0, nil
 	}
 	// Read the HCI packet without advancing buffer.
@@ -250,7 +251,7 @@ func (d *Device) hci_buffered() (uint32, error) {
 	}
 	buffered := uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16
 	buffered += 4 // Add HCI header.
-	d.debug("hci_buffered", slog.Uint64("buffered", uint64(buffered)), slog.Uint64("avail", uint64(available)))
+	d.debug("hci_buffered", slog.Uint64("buffered", uint64(buffered)), slog.Uint64("unread", uint64(unread)))
 	d.hci_ringbuf_debug()
 	return buffered, nil
 }
@@ -290,9 +291,9 @@ func (d *Device) hci_read(b []byte) (uint32, error) {
 func (d *Device) hci_wait_read_buffered(n int) error {
 	d.trace("hci_wait_read_buffered", slog.Int("n", n))
 	for {
-		// Block on no data available.
-		available, err := d.hci_available_ringbuf()
-		if int(available) >= n {
+		// Block until at least n bytes are unread.
+		unread, err := d.hci_unread_bytes()
+		if int(unread) >= n {
 			break
 		} else if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes and renames the function `hci_available_ringbuf` to be less ambiguous. It was unclear if this returned the size of available buffer or the size of available bytes to read.

I'm not an expert at writing bluetooth drivers, so hopefully I got this right. In debugging some edge cases on my Pico 2 W project I noticed that occasionally things just seemed to "hang" and I stopped getting events or was unable to stop scanning.

I believe this codebase used the return of the function `hci_available_ringbuf()` as the number of bytes available to consume in the ring buffer. This would be:

```
newPtr(pointer to what has been written) - d.b2hReadPtr(pointer to what we have read) 
    % BUFFER_SZ = available to read
```

However, the function itself does not return this. Instead it returns:
```
 d.b2hReadPtr(pointer to what we have read) - newPtr(pointer to what has been written)  
     % BUFFER_SZ = free space remaining in buffer
 
 Note these are uint32 so for example we have read to 10 minus chip has written to 20, returns -10 which wraps to max uint32 - 10, then modulo BUFFER_SZ of 4096 ends up returning 4086 bytes.
 ```
 This doesn't always result in issues until the buffer fills, since a nearly empty buffer will return a high number and allow you to read, so congested bluetooth environments or code that doesn't read the device often enough to keep the buffer empty increase the odds of triggering the hang. 
 
 I think it also causes some corruption on occasion, or I have also seen `"short buffer length=16777216"` errors thrown when this function returns a high number that really indicates there is no or very little data in the ring buffer (lots of available space in the buffer, rather than lots of data available to read).
 
 I have a reproducer script pointed at the cyw4349 repo locally. It simply starts a scan and waits a bit before starting to ReadHCI(), and when we do that there is enough bluetooth traffic to fill the buffer and we are never able to read.
 
 with main:
 ```
 % tinygo flash --target pico2-w main.go; tinygo monitor
Connected to /dev/cu.usbmodem201201. Press Ctrl-C to exit.
1970/01/01 00:00:01 scan started — letting ring buffer fill for a bit before draining
1970/01/01 00:00:01 now draining; evt counter will hang here on the bug
1970/01/01 00:00:02 alive tick=1
1970/01/01 00:00:03 alive tick=2
1970/01/01 00:00:04 alive tick=3
1970/01/01 00:00:05 alive tick=4
1970/01/01 00:00:06 alive tick=5
 ```
 with this PR:
 ```
  % tinygo flash --target pico2-w main.go; tinygo monitor
Connected to /dev/cu.usbmodem201201. Press Ctrl-C to exit.
1970/01/01 00:00:01 scan started — letting ring buffer fill for a bit before draining
1970/01/01 00:00:01 now draining; evt counter will hang here on the bug
1970/01/01 00:00:01 evt #50 (36 bytes)
1970/01/01 00:00:01 evt #100 (42 bytes)
1970/01/01 00:00:02 evt #150 (46 bytes)
1970/01/01 00:00:02 evt #200 (36 bytes)
1970/01/01 00:00:02 alive tick=1
1970/01/01 00:00:02 evt #250 (36 bytes)
1970/01/01 00:00:02 evt #300 (36 bytes)
1970/01/01 00:00:03 evt #350 (36 bytes)
1970/01/01 00:00:03 evt #400 (46 bytes)
1970/01/01 00:00:03 alive tick=2
 ``` 
 
 reproducer:
 ```
 package main

import (
	"log"
	"time"

	"github.com/soypat/cyw43439"
)

func main() {
	dev := cyw43439.NewPicoWDevice()
	if err := dev.Init(cyw43439.DefaultBluetoothConfig()); err != nil {
		log.Fatal(err)
	}

	// Reset (opcode 0x0C03)
	dev.WriteHCI([]byte{0x01, 0x03, 0x0C, 0x00})
	time.Sleep(200 * time.Millisecond)

	// LE Set Event Mask (0x2001) — enable all LE meta events
	dev.WriteHCI([]byte{0x01, 0x01, 0x20, 0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
	time.Sleep(200 * time.Millisecond)

	// LE Set Scan Enable (0x200C) — enable, no filter dup
	dev.WriteHCI([]byte{0x01, 0x0c, 0x20, 0x02, 0x01, 0x00})

        // print something on interval in the background to show we are running
	go func() {
		for tick := 1; ; tick++ {
			time.Sleep(time.Second)
			log.Printf("alive tick=%d", tick)
		}
	}()

	log.Println("scan started — letting ring buffer fill for a bit before draining")
	time.Sleep(1 * time.Second)
	log.Println("now draining; evt counter will hang here on the bug, not printing evt messages")

	var rx [256]byte
	count := 0
	for {
		if dev.BufferedHCI() > 0 {
			n, _ := dev.ReadHCI(rx[:])
			count++
			if count%50 == 0 {
				log.Printf("evt #%d (%d bytes)", count, n)
			}
		} else {
			time.Sleep(5 * time.Millisecond)
		}
	}
}
 ```